### PR TITLE
Rama para markdown

### DIFF
--- a/blog/templates/articulos.html
+++ b/blog/templates/articulos.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-
+{% load markdown_extras %}
 
 {% block title %} {{ publicacion.titulo }} {% endblock %}
 
@@ -21,7 +21,7 @@
     <hr>
 </div>
 <br/>
-<p class="text-justify">{{ publicacion.cuerpo}}</p>
+<p class="text-justify">{{ publicacion.cuerpo|markdown|safe}}</p>
 <br/><br/>
 <div class="text-success">
     <hr>

--- a/blog/templates/index.html
+++ b/blog/templates/index.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-
+{% load markdown_extras %}
 {% block Contenido %}
 <h1>Publicaciones</h1>
 <div class="card-deck">
@@ -7,7 +7,7 @@
       <div class="card mb-4">
         <div class="card-body">
           <h5 class="card-title">{{ publicacion.titulo }}</h5>
-          <p class="card-text">{{ publicacion.cuerpo }}</p>
+          <p class="card-text">{{ publicacion.cuerpo|markdown|safe }}</p>
           <a href="{% url 'Articulos' pk=publicacion.pk %}" class="btn btn-secondary">Ver Detalles</a>
         </div>
       </div>

--- a/blog/templatetags/markdown_extras.py
+++ b/blog/templatetags/markdown_extras.py
@@ -5,4 +5,4 @@ register = template.Library()
 
 @register.filter(name='markdown')
 def markdown(text):
-    return md.markdown(text, extensions=['fenced_code','codehillite'])
+    return md.markdown(text, extensions=['fenced_code','codehilite'])


### PR DESCRIPTION
Corregí un typo de codehilite, 
![chrome_UxbaovpoAC](https://github.com/belenAlcaraz/DjangoBlog/assets/3680835/8c4ad2fd-004f-431d-80f0-f5b1766380a1)
Probá si te funciona con este cambio